### PR TITLE
Changed baseURL to HTTPS

### DIFF
--- a/resources/service.php
+++ b/resources/service.php
@@ -9,7 +9,7 @@
  */
 
 return [
-    'baseUrl' => 'http://api.discogs.com/',
+    'baseUrl' => 'https://api.discogs.com/',
     'operations' => [
         'getArtist' => [
             'httpMethod' => 'GET',


### PR DESCRIPTION
This is required for the Discogs Auth Flow (Alternative to OAuth Flow). Docs: http://www.discogs.com/developers/#page:authentication,header:authentication-discogs-auth-flow