### PR TITLE
createListing: status-parameter is now required

### DIFF
--- a/resources/service.php
+++ b/resources/service.php
@@ -372,7 +372,7 @@ return [
                 'status' => [
                     'type' => 'string',
                     'location' => 'json',
-                    'required' => false,
+                    'required' => true,
                 ],
                 'external_id' => [
                     'type' => 'string',

--- a/tests/Discogs/Test/ClientTest.php
+++ b/tests/Discogs/Test/ClientTest.php
@@ -244,12 +244,23 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('http://api.discogs.com/marketplace/orders/1-1', $history->getLastRequest()->getUrl());
     }
 
+    public function testCreateListingValidation(){
+        $this->setExpectedException('GuzzleHttp\Command\Exception\CommandException', 'Validation errors: [status] is a required string');
+        $client = $this->createClient('create_listing', $history = new History());
+        $client->createListing([
+            'release_id' => '1',
+            'condition' => 'Mint (M)',
+            'price' => 5.90
+        ]);
+    }
+
     public function testCreateListing()
     {
         $client = $this->createClient('create_listing', $history = new History());
         $response = $client->createListing([
             'release_id' => '1',
-            'condition'   => 'Mint (M)',
+            'condition' => 'Mint (M)',
+            'status' => 'For Sale',
             'price' => 5.90
         ]);
 


### PR DESCRIPTION
see api-doc: https://www.discogs.com/developers/#page:marketplace,header:marketplace-new-listing
I noticed this change in the discogs-API-definition and updated this client accordingly