### PR TITLE
changing parameter name of order_id in getOrder & changeOrder

### DIFF
--- a/resources/service.php
+++ b/resources/service.php
@@ -278,10 +278,10 @@ return [
         ],
         'getOrder' => [
             'httpMethod' => 'GET',
-            'uri' => 'marketplace/orders/{id}',
+            'uri' => 'marketplace/orders/{order_id}',
             'responseModel' => 'GetResponse',
             'parameters' => [
-                'id' => [
+                'order_id' => [
                     'type' => 'string',
                     'location' => 'uri',
                     'required' => true
@@ -312,11 +312,11 @@ return [
         ],
         'changeOrder' => [
             'httpMethod' => 'POST',
-            'uri' => 'marketplace/orders/{id}',
+            'uri' => 'marketplace/orders/{order_id}',
             'summary' => 'Edit the data associated with an order.',
             'responseModel' => 'GetResponse',
             'parameters' => [
-                'id' => [
+                'order_id' => [
                     'type' => 'string',
                     'location' => 'uri',
                     'required' => true

--- a/tests/Discogs/Test/ClientTest.php
+++ b/tests/Discogs/Test/ClientTest.php
@@ -209,7 +209,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->createClient('get_order', $history = new History());
         $response = $client->getOrder([
-            'id' => '1-1'
+            'order_id' => '1-1'
         ]);
 
         $this->assertArrayHasKey('id', $response);
@@ -236,7 +236,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->createClient('change_order', $history = new History());
         $response = $client->changeOrder([
-            'id'        => '1-1',
+            'order_id'  => '1-1',
             'shipping'  => 5.0
         ]);
 


### PR DESCRIPTION
The parameter for getOrder & changeOrder is called `order_id` instead of `id`, see: https://www.discogs.com/developers/#page:marketplace,header:marketplace-order-post