### PR TITLE
Should Fix php notice on default config params merge + Readme addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ $client->getHttpClient()->getEmitter()->attach(new Discogs\Subscriber\ThrottleSu
 
 ```
 
+#### Authentication
+
+Discogs API allow to access protected endpoints with either a simple [Discogs Auth Flow](https://www.discogs.com/developers/#page:authentication,header:authentication-discogs-auth-flow) or a more advanced (and more complex) [Oauth Flow](https://www.discogs.com/developers/#page:authentication,header:authentication-oauth-flow)
+
+### Discogs Auth
+
+As stated in the Discogs Authentication documentation:
+> In order to access protected endpoints, you’ll need to register for either a consumer key and secret or user token, depending on your situation:
+> - To easily access your own user account information, use a *User token*.
+> - To get access to an endpoint that requires authentication and build 3rd party apps, use a *Consumer Key and Secret*.
+
+With the Discogs Php API you can add your credentials to each request by adding a `query` key to your own defaults like this:
+```php
+$client = ClientFactory::factory([
+    'defaults' => [
+        'query' => [
+            'key' => 'my-key',
+            'secret' => 'my-secret',
+        ],
+    ]
+]);
+```
+
 ### OAuth
 There are a lot of endpoints which require OAuth. Lucky for you using Guzzle this is peanuts. If you're having trouble obtaining the token and token_secret, please check out my [example implementation](https://github.com/ricbra/php-discogs-api-example).
 

--- a/lib/Discogs/ClientFactory.php
+++ b/lib/Discogs/ClientFactory.php
@@ -39,7 +39,7 @@ class ClientFactory
         if (is_array($array2)) {
             foreach ($array2 as $key => $val) {
                 if (is_array($array2[$key])) {
-                    $merged[$key] = is_array($merged[$key]) ? self::mergeRecursive($merged[$key], $array2[$key]) : $array2[$key];
+                    $merged[$key] = isset($merged[$key]) && is_array($merged[$key]) ? self::mergeRecursive($merged[$key], $array2[$key]) : $array2[$key];
                 } else {
                     $merged[$key] = $val;
                 }

--- a/tests/Discogs/Test/ClientFactoryTest.php
+++ b/tests/Discogs/Test/ClientFactoryTest.php
@@ -29,4 +29,26 @@ class ClientFactoryTest extends \PHPUnit_Framework_TestCase
         $default = ['User-Agent' => 'test'];
         $this->assertSame($default, $client->getHttpClient()->getDefaultOption('headers'));
     }
+
+
+    public function testFactoryWithCustomDefaultNotInClassDefaults()
+    {
+        $client = ClientFactory::factory([
+            'defaults' => [
+                'headers' => ['User-Agent' => 'test'],
+                'query' => [
+                    'key' => 'my-key',
+                    'secret' => 'my-secret',
+                ],
+            ]
+        ]);
+        $default_headers = ['User-Agent' => 'test'];
+        $default_query = [
+                'key' => 'my-key',
+                'secret' => 'my-secret'
+        ];
+        $this->assertSame($default_headers, $client->getHttpClient()->getDefaultOption('headers'));
+        $this->assertSame($default_query, $client->getHttpClient()->getDefaultOption('query'));
+    }
+
 }


### PR DESCRIPTION
This is a PR to fix a php notice that appears when one tries to declare a custom defaults array where a key is used that is not present in the `$defaultConfig` array declared in the `ClientFactory` `factory` function

I've included a simple test but maybe that' s not enough

also added a non directly related change in the `Readme` to inform that the Discogs API allow for a simple auth mechanism - related to #43 

let me know what you think and thanks for your work!