### PR TITLE
Added getWantlist

### DIFF
--- a/resources/service.php
+++ b/resources/service.php
@@ -468,6 +468,28 @@ return [
                     'required' => false
                 ]
             ]
+        ],
+        'getWantlist' => [
+            'httpMethod' => 'GET',
+            'uri' => 'users/{username}/wants',
+            'responseModel' => 'GetResponse',
+            'parameters' => [
+                'username' => [
+                    'type' => 'string',
+                    'location' => 'uri',
+                    'required' => true
+                ],
+                'per_page' => [
+                  'type' => 'integer',
+                  'location' => 'query',
+                  'required' => false
+                ],
+                'page' => [
+                    'type' => 'integer',
+                    'location' => 'query',
+                    'required' => false
+                ]
+            ]
         ]
     ],
     'models' => [

--- a/tests/Discogs/Test/ClientTest.php
+++ b/tests/Discogs/Test/ClientTest.php
@@ -340,6 +340,23 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('GET', $history->getLastRequest()->getMethod());
     }
 
+    public function testGetWantlist()
+    {
+        $history = new History();
+        $client = $this->createClient('get_wantlist', $history);
+        $response = $client->getWantlist([
+            'username' => 'Rock_it_science',
+            'per_page' => 25,
+            'page' => 1
+        ]);
+
+        $this->assertArrayHasKey('pagination', $response);
+        $this->assertArrayHasKey('releases', $response);
+        $this->assertCount(25, $response['releases']);
+        $this->assertSame('https://www.discogs.com/mywantlist?page=1&limit=25', $history->getLastRequest()->getUrl());
+        $this->assertSame('GET', $history->getLastRequest()->getMethod());
+    }
+
     protected function createClient($mock, History $history)
     {
         $path = sprintf('%s/../../fixtures/%s', __DIR__, $mock);


### PR DESCRIPTION
getWantlist was missing from this API so I added it here.
I was unable to get the tests to pass on my own despite the code not having any errors that I have been able to find. From what I've read about the error it is a Guzzle version problem, but somehow all the other tests still pass. I submitted the PR as I thought it was just happening on my machine, and I'm confident there's nothing wrong with the service I submitted. Maybe someone could take a look at this and tell me if its my test or some weird Guzzle problem?